### PR TITLE
Additional Queries for TcCaseAuditService

### DIFF
--- a/projects/tibco-tcstk/tc-liveapps-lib/src/lib/components/live-apps-case-audit/live-apps-case-audit.component.ts
+++ b/projects/tibco-tcstk/tc-liveapps-lib/src/lib/components/live-apps-case-audit/live-apps-case-audit.component.ts
@@ -2,7 +2,7 @@ import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {map, take, takeUntil} from 'rxjs/operators';
 import {AuditEvent} from '../../models/tc-case-audit';
 import {LiveAppsComponent} from '../live-apps-component/live-apps-component.component';
-import {TcCaseAuditService} from '../../services/tc-case-audit.service';
+import { TcCaseAuditService, OrderBy, CaseTypeAudit} from '../../services/tc-case-audit.service';
 
 /**
  * Render audit trail for a case
@@ -28,6 +28,21 @@ export class LiveAppsCaseAuditComponent extends LiveAppsComponent implements OnD
    */
   @Input() sandboxId: number;
 
+  /**
+   * creationTime - specify the date to include cases from using the format yyyy-mm-ddTHH:MM:SS.sssZ
+   */
+  @Input() creationTime: string;
+
+  /**
+   * caseType - speficy the type of the case
+   */
+  @Input() caseType: CaseTypeAudit;
+
+  /**
+   * orderBy - specify ascending or descending order
+   */
+  @Input() orderby: OrderBy;
+
   public auditEvents: AuditEvent[] = [];
   public errorMessage: string;
   public startat = undefined;
@@ -39,11 +54,12 @@ export class LiveAppsCaseAuditComponent extends LiveAppsComponent implements OnD
     this.top = 20;
     this.end = false;
     this.auditEvents = [];
-    this.getAuditEvents(this.caseRef, this.sandboxId, this.startat, this.top);
+    this.getAuditEvents(this.caseRef, this.sandboxId, this.startat, this.top, this.creationTime, this.caseType, this.orderby);
   }
 
-  public getAuditEvents = (caseRef: string, sandboxId: number, startAt: number, top: number) => {
-    this.caseAuditService.getCaseAudit(this.caseRef, this.sandboxId, this.startat, this.top)
+  public getAuditEvents = (caseRef: string, sandboxId: number, startAt: number, top: number,
+    creationTime: string, caseType: CaseTypeAudit, orderBy: OrderBy) => {
+    this.caseAuditService.getCaseAudit(this.caseRef, this.sandboxId, this.startat, this.top, this.creationTime, this.caseType, this.orderby)
       .pipe(
         take(1),
         takeUntil(this._destroyed$)
@@ -64,7 +80,7 @@ export class LiveAppsCaseAuditComponent extends LiveAppsComponent implements OnD
 
   public getNextBatch = (event) => {
     if (!this.end) {
-      this.getAuditEvents(this.caseRef, this.sandboxId, this.startat, this.top);
+      this.getAuditEvents(this.caseRef, this.sandboxId, this.startat, this.top, this.creationTime, this.caseType, this.orderby);
     }
   }
 

--- a/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
+++ b/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
@@ -12,7 +12,7 @@ export class TcCaseAuditService {
   constructor(private http: HttpClient) { }
 
   public getCaseAudit(caseRef: string, sandboxId: number, startAt: string, top: number,
-    creationTime: string, caseType: CaseTypeAudit, orderBy: OrderBy): Observable<AuditEventList> {
+    creationTime?: string, caseType?: CaseTypeAudit, orderBy?: OrderBy): Observable<AuditEventList> {
 
     const select = 's';
     let url = '/event/v1/auditEvents?$sandbox=' + sandboxId

--- a/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
+++ b/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
@@ -16,7 +16,7 @@ export class TcCaseAuditService {
 
     const select = 's';
     let url = '/event/v1/auditEvents?$sandbox=' + sandboxId
-      + '&$filter=type eq \'' + caseType + '\''
+      + '&$filter=type eq \'' + ((caseType !== undefined) ? caseType : 'case') + '\''
       + ' and id eq \'' + caseRef + '\'';
     url = (creationTime !== undefined) ? (url + ' and creationTime gt ' + creationTime) : url;
     url = (startAt !== undefined) ? (url + '&$startat=' + startAt) : url;

--- a/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
+++ b/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
@@ -11,17 +11,32 @@ export class TcCaseAuditService {
 
   constructor(private http: HttpClient) { }
 
-  public getCaseAudit(caseRef: string, sandboxId: number, startAt: string, top: number): Observable<AuditEventList> {
+  public getCaseAudit(caseRef: string, sandboxId: number, startAt: string, top: number,
+    creationTime: string, caseType: CaseTypeAudit, orderBy: OrderBy): Observable<AuditEventList> {
+
     const select = 's';
     let url = '/event/v1/auditEvents?$sandbox=' + sandboxId
-      + '&$filter=type eq \'case\''
+      + '&$filter=type eq \'' + caseType + '\''
       + ' and id eq \'' + caseRef + '\'';
+    url = (creationTime !== undefined) ? (url + ' and creationTime gt ' + creationTime) : url;
     url = (startAt !== undefined) ? (url + '&$startat=' + startAt) : url;
     url = top ? (url + '&$top=' + top) : url;
+    url = (orderBy !== undefined) ? (url + '&orderby=creationTime ' + orderBy) : url;
 
     return this.http.get(url)
       .pipe(
         tap( val => sessionStorage.setItem('tcsTimestamp', Date.now().toString())),
         map(caseaudit => new AuditEventList().deserialize(caseaudit)));
   }
+}
+
+export enum OrderBy {
+  asc,
+  desc
+}
+
+export enum CaseTypeAudit {
+  case,
+  casestate,
+  casedata
 }

--- a/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
+++ b/projects/tibco-tcstk/tc-liveapps-lib/src/lib/services/tc-case-audit.service.ts
@@ -16,12 +16,12 @@ export class TcCaseAuditService {
 
     const select = 's';
     let url = '/event/v1/auditEvents?$sandbox=' + sandboxId
-      + '&$filter=type eq \'' + ((caseType !== undefined) ? caseType : 'case') + '\''
+      + '&$filter=type eq \'' + (caseType ? caseType : 'case') + '\''
       + ' and id eq \'' + caseRef + '\'';
-    url = (creationTime !== undefined) ? (url + ' and creationTime gt ' + creationTime) : url;
-    url = (startAt !== undefined) ? (url + '&$startat=' + startAt) : url;
+    url = creationTime ? (url + ' and creationTime gt ' + creationTime) : url;
+    url = startAt ? (url + '&$startat=' + startAt) : url;
     url = top ? (url + '&$top=' + top) : url;
-    url = (orderBy !== undefined) ? (url + '&orderby=creationTime ' + orderBy) : url;
+    url = orderBy ? (url + '&orderby=creationTime ' + orderBy) : url;
 
     return this.http.get(url)
       .pipe(

--- a/projects/tibco-tcstk/tc-liveapps-lib/src/public_api.ts
+++ b/projects/tibco-tcstk/tc-liveapps-lib/src/public_api.ts
@@ -95,6 +95,7 @@ export * from './lib/services/tc-case-card-config.service';
 export * from './lib/services/tc-workitems.service';
 export * from './lib/services/tc-form-config.service';
 export * from './lib/services/tc-app-definition.service';
+export * from './lib/services/tc-case-audit.service';
 
 // resolvers
 export * from './lib/resolvers/claims.resolver';


### PR DESCRIPTION
**Story**
The user may want to have a more refined view of the live apps audit trail using additional options such as caseType, creationTime, and to have the results sorted.

**Changes**
1. Added `@Input()` to LiveAppsCaseAuditComponent to take creationTime, caseType, and orderBy
1. Modified the query parameters used when building the audiEvents URL to include the new options

**Tests**
It would be practical to test the API construction and use before publishing.